### PR TITLE
Fix ComplexSpectralDifference formula, add CSD-Squared

### DIFF
--- a/src/BTrack.cpp
+++ b/src/BTrack.cpp
@@ -25,19 +25,19 @@
 #include "samplerate.h"
 
 //=======================================================================
-BTrack::BTrack() : odf(512,1024,ComplexSpectralDifferenceHWR,HanningWindow)
+BTrack::BTrack() : odf(512,1024,ComplexSpectralDifference,HanningWindow)
 {
     initialise(512, 1024);
 }
 
 //=======================================================================
-BTrack::BTrack(int hopSize_) : odf(hopSize_,2*hopSize_,ComplexSpectralDifferenceHWR,HanningWindow)
+BTrack::BTrack(int hopSize_) : odf(hopSize_,2*hopSize_,ComplexSpectralDifferenceSquaredHWR,HanningWindow)
 {	
     initialise(hopSize_, 2*hopSize_);
 }
 
 //=======================================================================
-BTrack::BTrack(int hopSize_,int frameSize_) : odf(hopSize_,frameSize_,ComplexSpectralDifferenceHWR,HanningWindow)
+BTrack::BTrack(int hopSize_,int frameSize_) : odf(hopSize_,frameSize_,ComplexSpectralDifferenceSquaredHWR,HanningWindow)
 {
     initialise(hopSize_, frameSize_);
 }

--- a/src/OnsetDetectionFunction.h
+++ b/src/OnsetDetectionFunction.h
@@ -36,6 +36,8 @@ enum OnsetDetectionFunctionType
     PhaseDeviation,
     ComplexSpectralDifference,
     ComplexSpectralDifferenceHWR,
+    ComplexSpectralDifferenceSquared,
+    ComplexSpectralDifferenceSquaredHWR,
     HighFrequencyContent,
     HighFrequencySpectralDifference,
     HighFrequencySpectralDifferenceHWR
@@ -129,6 +131,12 @@ private:
     
     /** Calculate complex spectral difference detection function sample (half-wave rectified) */
 	double complexSpectralDifferenceHWR();
+    
+    /** Calculate complex spectral difference squared detection function sample */
+	double complexSpectralDifferenceSquared();
+    
+    /** Calculate complex spectral difference squared detection function sample (half-wave rectified) */
+	double complexSpectralDifferenceSquaredHWR();
     
     /** Calculate high frequency content detection function sample */
 	double highFrequencyContent();


### PR DESCRIPTION
It looks like there was a mistake in the formula used in calculating the Onset Detection Function, in ``complexSpectralDifference`` and ``complexSpectralDifferenceHWR``.

The previous formula computed the difference between two complex numbers **x** and **y** as:
``|x - y| = sqrt((|x| - |y|)^2 + (|x| sin(angle(x, y))^2 )``

I changed this to:
``|x - y| = sqrt(|x|^2 + |y|^2 - 2 |x| |y| cos(angle(x, y)))``

I also added ``complexSpectralDifferenceSquared`` and ``complexSpectralDifferenceSquaredHWR``, making the latter the default, following the description in the Davies & Plumbley 2007 and 2004 papers. Testing a few problematic songs, it seemed to work better, but I haven't tested it extensively.

I also cleaned up trailing tabs -- sorry for the diff noise.